### PR TITLE
Add time stamp to service job parameters

### DIFF
--- a/docs/geoprocessing/api.rst
+++ b/docs/geoprocessing/api.rst
@@ -195,3 +195,32 @@ A jQuery Example
             }
         });
     }
+
+
+Loading Service Data with `RasterParameter`
+-------------------------------------------
+
+For tasks with a ``RasterParameter`` or ``NdArrayParameter`` input, the client can pass a reference to a published
+service which will be automatically loaded into memory as a ``Raster`` object and passed to the task as an input. To
+do this, the client should pass, as the input, a string with the following format:
+``service://<service name>:<variable name>@<timestamp (optional)>``. The timestamp is a Unix-style timestamp
+representing the seconds since January 1, 1970.
+
+.. note::
+
+    The Unix-style timestamp is represented in seconds, unlike the Java/JavaScript timestamp, which is represented in
+    milliseconds. Therefore timestamps from Java or JavaScript need to be divided by 1000.
+
+In this example, a job is created where an input called ``data`` accepts a raster parameter, which will be filled
+with data from the ``tmax`` variable of a service called ``climate-service`` with the timestamp ``1501895290``.
+
+.. code-block:: text
+    POST GET /geoprocessing/rest/jobs/
+
+.. code-block:: json
+
+    {
+        "job": "some_job",
+        "inputs": "{\"data\": \"service://climate-service:tmax@1501895290\"}"
+    }
+

--- a/ncdjango/geoprocessing/params.py
+++ b/ncdjango/geoprocessing/params.py
@@ -12,7 +12,7 @@ from shapely.geometry.base import BaseGeometry
 
 from ncdjango.geoprocessing.data import Raster
 from ncdjango.models import Service
-from ncdjango.utils import best_fit
+from ncdjango.utils import best_fit, timestamp_to_date
 from ncdjango.views import NetCdfDatasetMixin
 
 
@@ -409,7 +409,7 @@ class RegisteredDatasetParameter(NetCdfDatasetMixin, Parameter):
                 value, timestamp = value.split('@', 1)
 
                 try:
-                    service_time = datetime.datetime.utcfromtimestamp(int(timestamp)).replace(tzinfo=pytz.utc)
+                    service_time = timestamp_to_date(int(timestamp))
                 except ValueError:
                     raise ParameterNotValidError
             else:
@@ -436,7 +436,7 @@ class RegisteredDatasetParameter(NetCdfDatasetMixin, Parameter):
                     time_index = best_fit(variable.time_stops, service_time)
                 else:
                     time_index = None
-                
+
                 data = self.get_grid_for_variable(variable, time_index=time_index)
                 return Raster(data, variable.full_extent, 1, 0, self.is_y_increasing(variable))
             else:

--- a/ncdjango/geoprocessing/params.py
+++ b/ncdjango/geoprocessing/params.py
@@ -436,7 +436,7 @@ class RegisteredDatasetParameter(NetCdfDatasetMixin, Parameter):
                     time_index = best_fit(variable.time_stops, service_time)
                 else:
                     time_index = None
-                print(time_index)
+                
                 data = self.get_grid_for_variable(variable, time_index=time_index)
                 return Raster(data, variable.full_extent, 1, 0, self.is_y_increasing(variable))
             else:

--- a/ncdjango/interfaces/arcgis/form_fields.py
+++ b/ncdjango/interfaces/arcgis/form_fields.py
@@ -144,7 +144,7 @@ class TimeField(forms.Field):
 
         try:
             if ',' in value:
-                return tuple([timestamp_to_date(int(x)) for x in value.split(',')])
+                return tuple([timestamp_to_date(int(x)//1000) for x in value.split(',')])
             else:
                 return datetime(int(value))
         except ValueError:
@@ -155,9 +155,9 @@ class TimeField(forms.Field):
             return value
 
         if isinstance(value, (tuple, list)):
-            return ",".join([str(date_to_timestamp(x)) for x in value])
+            return ",".join([str(date_to_timestamp(x)*1000) for x in value])
         else:
-            return str(date_to_timestamp(value))
+            return str(date_to_timestamp(value)*1000)
 
 
 class DynamicLayersField(forms.Field):

--- a/ncdjango/interfaces/arcgis/form_fields.py
+++ b/ncdjango/interfaces/arcgis/form_fields.py
@@ -9,9 +9,8 @@ from shapely.geometry.base import BaseGeometry
 from shapely.geometry.multilinestring import MultiLineString
 from shapely.geometry.point import Point
 from shapely.geometry.polygon import LinearRing, Polygon
-from ncdjango.interfaces.arcgis.utils import timestamp_to_date, date_to_timestamp
 from ncdjango.interfaces.arcgis.wkid import wkid_to_proj
-from ncdjango.utils import proj4_to_epsg
+from ncdjango.utils import proj4_to_epsg, timestamp_to_date, date_to_timestamp
 
 
 class BoundingBoxField(forms.Field):

--- a/ncdjango/interfaces/arcgis/utils.py
+++ b/ncdjango/interfaces/arcgis/utils.py
@@ -1,15 +1,3 @@
-from datetime import datetime, timedelta
-from django.utils.timezone import utc
-
-
-def date_to_timestamp(date_obj):
-    return int((date_obj - datetime.utcfromtimestamp(0).replace(tzinfo=utc)).total_seconds() * 1000)
-
-
-def timestamp_to_date(timestamp):
-    return datetime.utcfromtimestamp(0).replace(tzinfo=utc) + timedelta(seconds=int(timestamp / 1000))
-
-
 def extent_to_envelope(extent, wkid):
     extent = {k: getattr(extent, k) for k in ('xmin', 'ymin', 'xmax', 'ymax')}
     extent['spatialReference'] = {'wkid': wkid}

--- a/ncdjango/interfaces/arcgis/views.py
+++ b/ncdjango/interfaces/arcgis/views.py
@@ -14,9 +14,9 @@ import six
 from ncdjango.config import RenderConfiguration, IdentifyConfiguration, LegendConfiguration, ImageConfiguration
 from ncdjango.exceptions import ConfigurationError
 from ncdjango.interfaces.arcgis.forms import GetImageForm, IdentifyForm
-from ncdjango.interfaces.arcgis.utils import date_to_timestamp, extent_to_envelope
+from ncdjango.interfaces.arcgis.utils import extent_to_envelope
 from ncdjango.models import Service, Variable
-from ncdjango.utils import proj4_to_epsg
+from ncdjango.utils import proj4_to_epsg, date_to_timestamp
 from ncdjango.views import GetImageViewBase, IdentifyViewBase, LegendViewBase, FORCE_WEBP
 
 ALLOW_BEST_FIT_TIME_INDEX = getattr(settings, 'NC_ALLOW_BEST_FIT_TIME_INDEX', True)

--- a/ncdjango/interfaces/arcgis/views.py
+++ b/ncdjango/interfaces/arcgis/views.py
@@ -97,7 +97,9 @@ class MapServiceDetailView(DetailView):
 
         if self.object.supports_time:
             data['timeInfo'] = {
-                'timeExtent': [date_to_timestamp(self.object.time_start), date_to_timestamp(self.object.time_end)],
+                'timeExtent': [
+                    date_to_timestamp(self.object.time_start)*1000, date_to_timestamp(self.object.time_end)*1000
+                ],
                 'timeRelation': 'esriTimeRelationOverlaps',
                 'defaultTimeInterval': self.object.time_interval,
                 'defaultTimeIntervalUnits': TIME_UNITS_MAP.get(self.object.time_interval_units),
@@ -173,7 +175,7 @@ class LayerDetailView(DetailView):
 
         if variable.supports_time:
             data['timeInfo'] = {
-                'timeExtent': [date_to_timestamp(variable.time_start), date_to_timestamp(variable.time_end)],
+                'timeExtent': [date_to_timestamp(variable.time_start)*1000, date_to_timestamp(variable.time_end)*1000],
                 'timeInterval': variable.service.time_interval,
                 'timeIntervalUnits': TIME_UNITS_MAP.get(variable.service.time_interval_units),
                 'exportOptions': {

--- a/ncdjango/utils.py
+++ b/ncdjango/utils.py
@@ -102,8 +102,8 @@ def project_geometry(geometry, source, target):
 
 
 def timestamp_to_date(timestamp):
-    return datetime.utcfromtimestamp(0).replace(tzinfo=utc) + timedelta(seconds=int(timestamp / 1000))
+    return datetime.utcfromtimestamp(0).replace(tzinfo=utc) + timedelta(seconds=timestamp)
 
 
 def date_to_timestamp(date_obj):
-    return int((date_obj - datetime.utcfromtimestamp(0).replace(tzinfo=utc)).total_seconds() * 1000)
+    return int((date_obj - datetime.utcfromtimestamp(0).replace(tzinfo=utc)).total_seconds())

--- a/ncdjango/utils.py
+++ b/ncdjango/utils.py
@@ -1,9 +1,11 @@
 from bisect import bisect_left
+from datetime import datetime, timedelta
 from functools import wraps, partial
 import os
 import re
 import osgeo
 import pyproj
+from django.utils.timezone import utc
 from shapely.ops import transform
 
 EPSG_RE = re.compile(r'\+init=epsg:([0-9]+)')
@@ -97,3 +99,11 @@ def project_geometry(geometry, source, target):
     )
 
     return transform(project, geometry)
+
+
+def timestamp_to_date(timestamp):
+    return datetime.utcfromtimestamp(0).replace(tzinfo=utc) + timedelta(seconds=int(timestamp / 1000))
+
+
+def date_to_timestamp(date_obj):
+    return int((date_obj - datetime.utcfromtimestamp(0).replace(tzinfo=utc)).total_seconds() * 1000)


### PR DESCRIPTION
This modifies the `service://` syntax that clients can use to pass services to geoprocessing jobs requiring raster or array inputs. The new format is `service://<service-name>:<variable-name>@<timestamp>`.